### PR TITLE
Bump text.

### DIFF
--- a/bench.cabal
+++ b/bench.cabal
@@ -29,7 +29,7 @@ executable bench
                      , optparse-applicative >= 0.14.0.0 && < 0.18
                      , process              >= 1.3      && < 1.7
                      , silently             >= 1.1.1    && < 1.3
-                     , text                                < 1.3
+                     , text                                < 2.1
                      , turtle               >= 1.2.5    && < 1.7
   ghc-options:         -Wall -O2 -threaded
   other-modules:       Paths_bench


### PR DESCRIPTION
This allows `bench` to be built with more recent GHCs that ship with `text >= 2`.